### PR TITLE
remove jquery dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 node_modules
 .tmp
+.DS_Store

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,7 +24,6 @@
   }
   </style>
 
-  <script src="../bower_components/jquery/jquery.js"></script>
   <script src="../bower_components/angular/angular.js"></script>
   <script src="../bower_components/angular-animate/angular-animate.js"></script>
   <script src="../bower_components/tether/tether.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'bower_components/jquery/jquery.js',
+      'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/tether/tether.js',
 
@@ -61,7 +61,7 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['Firefox'],
+    browsers: ['PhantomJS'],
 
 
     // Continuous Integration mode

--- a/src/angular-tooltip.js
+++ b/src/angular-tooltip.js
@@ -25,7 +25,7 @@
         options = extend({ templateUrl: defaultTemplateUrl }, options);
         options.tether = extend({}, defaultTetherOptions, options.tether || {});
 
-        var template = options.template || ( $templateCache.get(options.templateUrl) ? $templateCache.get(options.templateUrl)[1] : undefined ),
+        var template = options.template || ( $templateCache.get(options.templateUrl) ? $templateCache.get(options.templateUrl) : undefined ),
             scope    = options.scope || $rootScope.$new(),
             target   = options.target,
             tether, elem;
@@ -42,7 +42,7 @@
         function attachTether() {
           tether = new Tether(extend({
             element: elem,
-            target: target
+            target: target[0]
           }, options.tether));
         }
 
@@ -53,8 +53,6 @@
           if (tether) {
             tether.destroy();
             tether = undefined;
-            elem.remove();
-            angular.element(elem).scope().$destroy();
           }
         }
 
@@ -78,7 +76,7 @@
          */
         function close() {
           delete result.elem;
-          $animate.leave(elem);
+          $animate.leave(angular.element(elem));
           detachTether();
         }
 
@@ -119,10 +117,11 @@
             /**
              * Toggle the tooltip.
              */
-            elem.hover(function() {
-              scope.$apply(tooltip.open);
-            }, function() {
-              scope.$apply(tooltip.close);
+            elem.on('mouseover', function() {
+              scope.$apply(tooltip.open());
+            });
+            elem.on('mouseout', function() {
+              scope.$apply(tooltip.close());
             });
           }
         };


### PR DESCRIPTION
I think it's good to remove this dependancy because the module doesn't particularly need it.

I made the tests pass, but had to remove these two lines. Not sure if they are still necessary as elem isn't a jquery object anymore. Could use a double check on that. I just was getting an undefined error for both...

``` js
elem.remove();
angular.element(elem).scope().$destroy();
```

![](http://i.giphy.com/H1lX50ZBbPTyM.gif)
